### PR TITLE
Add geometry as dependency for estimate_cell_adjacency (delaunayn)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,6 +22,7 @@ Imports:
     data.table,
     dplyr,
     FNN,
+    geometry,
     ggplot2,
     ggrastr,
     ggrepel,


### PR DESCRIPTION
The package "geometry" is not listed as a dependency but required (geometry::delaunayn called in estimate_cell_adjacency).