### PR TITLE
Incompatibility of get_counts_meta_seurat() with Matrix >= 1.5

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -10,14 +10,22 @@ get_counts_meta_seurat <- function(tx.dat, normalize=FALSE) {
   gene.factors <- factor(tx.dat$gene)
   cell.factors <- factor(tx.dat$cell)
 
+  # Aggregate duplicate (gene, cell) pairs — required for Matrix >= 1.5
+  idx_agg <- data.frame(
+    i = as.integer(gene.factors),
+    j = as.integer(cell.factors)
+  ) %>%
+    dplyr::group_by(i, j) %>%
+    dplyr::summarise(x = dplyr::n(), .groups = "drop")
+
   cm <- Matrix::sparseMatrix(
-    i = as.integer(gene.factors),  # Now rows are genes
-    j = as.integer(cell.factors),  # And columns are cells
-    x = rep(1, nrow(tx.dat)),      # Each row in `tx.dat` contributes 1 count
+    i = idx_agg$i,
+    j = idx_agg$j,
+    x = idx_agg$x,
     dims = c(length(levels(gene.factors)), length(levels(cell.factors))),
     dimnames = list(
-      levels(gene.factors),        # Row names (gene names)
-      levels(cell.factors)         # Column names (cell names)
+      levels(gene.factors),
+      levels(cell.factors)
     )
   )
 


### PR DESCRIPTION
Matrix >= 1.5 no longer aggregates duplicate (i, j) entries in sparseMatrix(). Duplicate indices can cause errors or wrong counts. Fix aggregates gene / cell counts before building the matrix. 